### PR TITLE
Fix for Missing Backpack Icons

### DIFF
--- a/Skins.lua
+++ b/Skins.lua
@@ -26,7 +26,7 @@ local Websites = {
 
 MSQ:AddSkin("Hex AmtoftEU", {
 	Shape = "Hexagon",
-	API_VERSION = 100207,
+	API_VERSION = 110000,
 
 	-- Skin
 	-- Mask = nil,

--- a/Skins.lua
+++ b/Skins.lua
@@ -427,6 +427,18 @@ MSQ:AddSkin("Hex AmtoftEU", {
 	SpellAlert = {
 		Height = 34,
 		Width = 34,
+		Classic = {
+			Height = 37,
+			Width = 37,
+		},
+		Modern = {
+			Height = 36,
+			Width = 36,
+		},
+		Thin = {
+			Height = 34,
+			Width = 34,
+		},
 	},
 }, true)
 
@@ -833,6 +845,18 @@ MSQ:AddSkin("Hex AmtoftEU Rotated", {
 	SpellAlert = {
 		Height = 34,
 		Width = 34,
+		Classic = {
+			Height = 37,
+			Width = 37,
+		},
+		Modern = {
+			Height = 36,
+			Width = 36,
+		},
+		Thin = {
+			Height = 34,
+			Width = 34,
+		},
 	},
 }, true)
 
@@ -1239,6 +1263,18 @@ MSQ:AddSkin("Hex AmtoftEU Clean", {
 	SpellAlert = {
 		Height = 34,
 		Width = 34,
+		Classic = {
+			Height = 38,
+			Width = 38,
+		},
+		Modern = {
+			Height = 38,
+			Width = 38,
+		},
+		Thin = {
+			Height = 34,
+			Width = 34,
+		},
 	},
 }, true)
 
@@ -1645,6 +1681,18 @@ MSQ:AddSkin("Hex AmtoftEU Clean Rotated", {
 	SpellAlert = {
 		Height = 34,
 		Width = 34,
+		Classic = {
+			Height = 38,
+			Width = 38,
+		},
+		Modern = {
+			Height = 38,
+			Width = 38,
+		},
+		Thin = {
+			Height = 34,
+			Width = 34,
+		},
 	},
 }, true)
 
@@ -2051,6 +2099,18 @@ MSQ:AddSkin("Hex AmtoftEU Black Border", {
 	SpellAlert = {
 		Height = 36,
 		Width = 36,
+		Classic = {
+			Height = 38,
+			Width = 38,
+		},
+		Modern = {
+			Height = 38,
+			Width = 38,
+		},
+		Thin = {
+			Height = 35,
+			Width = 35,
+		},
 	},
 }, true)
 
@@ -2457,6 +2517,18 @@ MSQ:AddSkin("Hex AmtoftEU Black Border Rotated", {
 	SpellAlert = {
 		Height = 36,
 		Width = 36,
+		Classic = {
+			Height = 38,
+			Width = 38,
+		},
+		Modern = {
+			Height = 38,
+			Width = 38,
+		},
+		Thin = {
+			Height = 35,
+			Width = 35,
+		},
 	},
 }, true)
 
@@ -2863,6 +2935,18 @@ MSQ:AddSkin("Hex Soft", {
 	SpellAlert = {
 		Height = 34,
 		Width = 34,
+		Classic = {
+			Height = 36,
+			Width = 36,
+		},
+		Modern = {
+			Height = 36,
+			Width = 36,
+		},
+		Thin = {
+			Height = 34,
+			Width = 34,
+		},
 	},
 }, true)
 
@@ -3269,6 +3353,18 @@ MSQ:AddSkin("Hex Soft Rotated", {
 	SpellAlert = {
 		Height = 34,
 		Width = 34,
+		Classic = {
+			Height = 36,
+			Width = 36,
+		},
+		Modern = {
+			Height = 36,
+			Width = 36,
+		},
+		Thin = {
+			Height = 34,
+			Width = 34,
+		},
 	},
 }, true)
 
@@ -3584,6 +3680,18 @@ MSQ:AddSkin("Hex Black Border Soft", {
 	SpellAlert = {
 		Height = 36,
 		Width = 36,
+		Classic = {
+			Height = 38,
+			Width = 38,
+		},
+		Modern = {
+			Height = 38,
+			Width = 38,
+		},
+		Thin = {
+			Height = 35,
+			Width = 35,
+		},
 	},
 }, true)
 
@@ -3899,6 +4007,18 @@ MSQ:AddSkin("Hex Black Border Soft Rotated", {
 	SpellAlert = {
 		Height = 36,
 		Width = 36,
+		Classic = {
+			Height = 38,
+			Width = 38,
+		},
+		Modern = {
+			Height = 38,
+			Width = 38,
+		},
+		Thin = {
+			Height = 35,
+			Width = 35,
+		},
 	},
 }, true)
 
@@ -4305,6 +4425,18 @@ MSQ:AddSkin("Hex Clean Soft", {
 	SpellAlert = {
 		Height = 34,
 		Width = 34,
+		Classic = {
+			Height = 38,
+			Width = 38,
+		},
+		Modern = {
+			Height = 38,
+			Width = 38,
+		},
+		Thin = {
+			Height = 34,
+			Width = 34,
+		},
 	},
 }, true)
 
@@ -4711,5 +4843,17 @@ MSQ:AddSkin("Hex Clean Soft Rotated", {
 	SpellAlert = {
 		Height = 34,
 		Width = 34,
+		Classic = {
+			Height = 38,
+			Width = 38,
+		},
+		Modern = {
+			Height = 38,
+			Width = 38,
+		},
+		Thin = {
+			Height = 34,
+			Width = 34,
+		},
 	},
 }, true)

--- a/Skins.lua
+++ b/Skins.lua
@@ -380,6 +380,19 @@ MSQ:AddSkin("Hex AmtoftEU", {
 		-- UseColor = nil,
 		-- SetAllPoints = nil,
 	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
+		-- SetAllPoints = nil,
+	},
 	AutoCastShine = {
 		Width = 35,
 		Height = 35,
@@ -771,6 +784,19 @@ MSQ:AddSkin("Hex AmtoftEU Rotated", {
 		OffsetX = 0,
 		OffsetY = 0,
 		-- UseColor = nil,
+		-- SetAllPoints = nil,
+	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon-Rotated\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
 		-- SetAllPoints = nil,
 	},
 	AutoCastShine = {
@@ -1166,6 +1192,19 @@ MSQ:AddSkin("Hex AmtoftEU Clean", {
 		-- UseColor = nil,
 		-- SetAllPoints = nil,
 	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
+		-- SetAllPoints = nil,
+	},
 	AutoCastShine = {
 		Width = 35,
 		Height = 35,
@@ -1557,6 +1596,19 @@ MSQ:AddSkin("Hex AmtoftEU Clean Rotated", {
 		OffsetX = 0,
 		OffsetY = 0,
 		-- UseColor = nil,
+		-- SetAllPoints = nil,
+	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon-Rotated\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
 		-- SetAllPoints = nil,
 	},
 	AutoCastShine = {
@@ -1952,6 +2004,19 @@ MSQ:AddSkin("Hex AmtoftEU Black Border", {
 		-- UseColor = nil,
 		-- SetAllPoints = nil,
 	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
+		-- SetAllPoints = nil,
+	},
 	AutoCastShine = {
 		Width = 35,
 		Height = 35,
@@ -2343,6 +2408,19 @@ MSQ:AddSkin("Hex AmtoftEU Black Border Rotated", {
 		OffsetX = 0,
 		OffsetY = 0,
 		-- UseColor = nil,
+		-- SetAllPoints = nil,
+	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon-Rotated\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
 		-- SetAllPoints = nil,
 	},
 	AutoCastShine = {
@@ -2738,6 +2816,19 @@ MSQ:AddSkin("Hex Soft", {
 		-- UseColor = nil,
 		-- SetAllPoints = nil,
 	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
+		-- SetAllPoints = nil,
+	},
 	AutoCastShine = {
 		Width = 35,
 		Height = 35,
@@ -3131,6 +3222,19 @@ MSQ:AddSkin("Hex Soft Rotated", {
 		-- UseColor = nil,
 		-- SetAllPoints = nil,
 	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon-Rotated\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
+		-- SetAllPoints = nil,
+	},
 	AutoCastShine = {
 		Width = 35,
 		Height = 35,
@@ -3433,6 +3537,19 @@ MSQ:AddSkin("Hex Black Border Soft", {
 		-- UseColor = nil,
 		-- SetAllPoints = nil,
 	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
+		-- SetAllPoints = nil,
+	},
 	AutoCastShine = {
 		Width = 35,
 		Height = 35,
@@ -3733,6 +3850,19 @@ MSQ:AddSkin("Hex Black Border Soft Rotated", {
 		OffsetX = 0,
 		OffsetY = 0,
 		-- UseColor = nil,
+		-- SetAllPoints = nil,
+	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon-Rotated\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
 		-- SetAllPoints = nil,
 	},
 	AutoCastShine = {
@@ -4128,6 +4258,19 @@ MSQ:AddSkin("Hex Clean Soft", {
 		-- UseColor = nil,
 		-- SetAllPoints = nil,
 	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
+		-- SetAllPoints = nil,
+	},
 	AutoCastShine = {
 		Width = 35,
 		Height = 35,
@@ -4519,6 +4662,19 @@ MSQ:AddSkin("Hex Clean Soft Rotated", {
 		OffsetX = 0,
 		OffsetY = 0,
 		-- UseColor = nil,
+		-- SetAllPoints = nil,
+	},
+	AutoCast_Mask = {
+		-- Atlas = "UI-HUD-ActionBar-PetAutoCast-Mask",
+		-- UseAtlasSize = false,
+		Texture = [[Interface\AddOns\Masque\Textures\Hexagon-Rotated\AutoCast-Mask]],
+		-- TexCoords = {0, 1, 0, 1},
+		Width = 36, -- 23
+		Height = 36, -- 23
+		Point = "CENTER",
+		RelPoint = "CENTER",
+		OffsetX = 0,
+		OffsetY = 0.5,
 		-- SetAllPoints = nil,
 	},
 	AutoCastShine = {

--- a/Skins.lua
+++ b/Skins.lua
@@ -45,6 +45,7 @@ MSQ:AddSkin("Hex AmtoftEU", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 36,
 		Height = 36,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -60,6 +61,7 @@ MSQ:AddSkin("Hex AmtoftEU", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	Shadow = {
 		Texture = [[Interface\AddOns\masque-hex\Textures\hex_shadow]],
 		-- TexCoords = {0, 1, 0, 1},
@@ -436,6 +438,7 @@ MSQ:AddSkin("Hex AmtoftEU Rotated", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 36,
 		Height = 36,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -451,6 +454,7 @@ MSQ:AddSkin("Hex AmtoftEU Rotated", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	Shadow = {
 		Texture = [[Interface\AddOns\masque-hex\Textures\hex_shadow_rotate]],
 		-- TexCoords = {0, 1, 0, 1},
@@ -827,6 +831,7 @@ MSQ:AddSkin("Hex AmtoftEU Clean", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 41,
 		Height = 41,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -842,6 +847,7 @@ MSQ:AddSkin("Hex AmtoftEU Clean", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	-- Shadow = {
 	-- 	Texture = [[Interface\AddOns\masque-hex\Textures\hex_shadow_rotate]],
 	-- 	-- TexCoords = {0, 1, 0, 1},
@@ -1218,6 +1224,7 @@ MSQ:AddSkin("Hex AmtoftEU Clean Rotated", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 41,
 		Height = 41,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -1233,6 +1240,7 @@ MSQ:AddSkin("Hex AmtoftEU Clean Rotated", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	-- Shadow = {
 	-- 	Texture = [[Interface\AddOns\masque-hex\Textures\hex_shadow_rotate]],
 	-- 	-- TexCoords = {0, 1, 0, 1},
@@ -1609,6 +1617,7 @@ MSQ:AddSkin("Hex AmtoftEU Black Border", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 41,
 		Height = 41,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -1624,6 +1633,7 @@ MSQ:AddSkin("Hex AmtoftEU Black Border", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	-- Shadow = {
 	-- 	Texture = [[Interface\AddOns\masque-hex\Textures\hex_shadow_rotate]],
 	-- 	-- TexCoords = {0, 1, 0, 1},
@@ -2000,6 +2010,7 @@ MSQ:AddSkin("Hex AmtoftEU Black Border Rotated", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 41,
 		Height = 41,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -2015,6 +2026,7 @@ MSQ:AddSkin("Hex AmtoftEU Black Border Rotated", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	-- Shadow = {
 	-- 	Texture = [[Interface\AddOns\masque-hex\Textures\hex_shadow_rotate]],
 	-- 	-- TexCoords = {0, 1, 0, 1},
@@ -2391,6 +2403,7 @@ MSQ:AddSkin("Hex Soft", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 36,
 		Height = 36,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -2406,6 +2419,7 @@ MSQ:AddSkin("Hex Soft", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	Shadow = {
 		Texture = [[Interface\AddOns\masque-hex\Textures\Soft\Regular\NS\hex_shadow]],
 		-- TexCoords = {0, 1, 0, 1},
@@ -2782,6 +2796,7 @@ MSQ:AddSkin("Hex Soft Rotated", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 36,
 		Height = 36,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -2797,6 +2812,7 @@ MSQ:AddSkin("Hex Soft Rotated", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	Shadow = {
 		Texture = [[Interface\AddOns\masque-hex\Textures\Soft\Regular\EW\hex_shadow]],
 		-- TexCoords = {0, 1, 0, 1},
@@ -3173,6 +3189,7 @@ MSQ:AddSkin("Hex Black Border Soft", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 41,
 		Height = 41,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -3188,6 +3205,7 @@ MSQ:AddSkin("Hex Black Border Soft", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	Normal = {
 		Texture = [[Interface\AddOns\masque-hex\Textures\Soft\Black\NS\hex_normal_black]],
 		-- TexCoords = {0, 1, 0, 1},
@@ -3473,6 +3491,7 @@ MSQ:AddSkin("Hex Black Border Soft Rotated", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 41,
 		Height = 41,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -3488,6 +3507,7 @@ MSQ:AddSkin("Hex Black Border Soft Rotated", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	Normal = {
 		Texture = [[Interface\AddOns\masque-hex\Textures\Soft\Black\EW\hex_normal_black]],
 		-- TexCoords = {0, 1, 0, 1},
@@ -3773,6 +3793,7 @@ MSQ:AddSkin("Hex Clean Soft", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 41,
 		Height = 41,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -3788,6 +3809,7 @@ MSQ:AddSkin("Hex Clean Soft", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	-- Shadow = {
 	-- 	Texture = [[Interface\AddOns\masque-hex\Textures\Soft\Clean\NS\hex_shadow_rotate]],
 	-- 	-- TexCoords = {0, 1, 0, 1},
@@ -4164,6 +4186,7 @@ MSQ:AddSkin("Hex Clean Soft Rotated", {
 		OffsetY = 0,
 	},
 	Icon = {
+		Texture = [[Interface\Icons\INV_Misc_Bag_08]],
 		Width = 41,
 		Height = 41,
 		TexCoords = {0.07,0.93,0.07,0.93},
@@ -4179,6 +4202,7 @@ MSQ:AddSkin("Hex Clean Soft Rotated", {
 		--OffsetY = 0,
 		-- SetAllPoints = nil,
 	},
+	SlotIcon = "Icon",
 	-- Shadow = {
 	-- 	Texture = [[Interface\AddOns\masque-hex\Textures\Soft\Clean\EW\hex_shadow_rotate]],
 	-- 	-- TexCoords = {0, 1, 0, 1},

--- a/masque-hex.toc
+++ b/masque-hex.toc
@@ -1,4 +1,4 @@
-## Interface: 100207
+## Interface: 11503, 30403, 40400, 110000
 ## Title: Masque: Hex
 
 ## Notes: Hex skin for Masque.

--- a/masque-hex.toc
+++ b/masque-hex.toc
@@ -9,7 +9,7 @@
 ## Notes-ruRU: Скин Hex для Masque.
 ## Notes-zhTW: Masque的Hex皮膚。
 
-## Version: 1.0.0
+## Version: 1.0.1
 ## Author: AmtoftEU
 ## Dependencies: Masque
 


### PR DESCRIPTION
With some of the UI changes in Dragonflight, the Backpack button's icon was removed. In order to remedy this, skins have to add the icon back, like so (pulled from Hex AmtoftEU):

```lua
	Icon = {
		Texture = [[Interface\Icons\INV_Misc_Bag_08]], -- Manually specify the icon
		Width = 36,
		Height = 36,
		TexCoords = {0.07,0.93,0.07,0.93},
		Mask = [[Interface\AddOns\masque-hex\Textures\hex_mask]],
		--TexCoords = {0.02, 0.98, 0.02, 0.98},
		--DrawLayer = "BACKGROUND",
		--DrawLevel = 0,
		--Width = 36,
		--Height = 36,
		--Point = "CENTER",
		--RelPoint = "CENTER",
		--OffsetX = 0,
		--OffsetY = 0,
		-- SetAllPoints = nil,
	},
	SlotIcon = "Icon", -- SlotIcon refers to the Dragonflight Backpack icon. SlotIcon = Icon tells Masque to use the Icon settings for the SlotIcon region.
```

This commit fixes issue #1 for all skins. Additionally, for future reference, any layer that uses the same exact settings as a another layer can reference the string name of that layer to save on memory. A prime example of this is `ContextOverlay` which uses the same settings as `SearchOverlay`. We can optimize this by changing:

```lua
	SearchOverlay = {
		-- Texture = nil,
		-- TexCoords = {0, 1, 0, 1},
		Color = {0, 0, 0, 0.7},
		BlendMode = "BLEND",
		DrawLayer = "OVERLAY",
		DrawLevel = 4,
		Width = 36,
		Height = 36,
		Point = "CENTER",
		RelPoint = "CENTER",
		OffsetX = 0,
		OffsetY = 0,
		UseColor = true,
		-- SetAllPoints = true,
	},
	ContextOverlay = {
		-- Texture = nil,
		-- TexCoords = {0, 1, 0, 1},
		Color = {0, 0, 0, 0.7},
		BlendMode = "BLEND",
		DrawLayer = "OVERLAY",
		DrawLevel = 4,
		Width = 36,
		Height = 36,
		Point = "CENTER",
		RelPoint = "CENTER",
		OffsetX = 0,
		OffsetY = 0,
		UseColor = true,
		-- SetAllPoints = true,
	},
```
To:
```lua
	SearchOverlay = {
		-- Texture = nil,
		-- TexCoords = {0, 1, 0, 1},
		Color = {0, 0, 0, 0.7},
		BlendMode = "BLEND",
		DrawLayer = "OVERLAY",
		DrawLevel = 4,
		Width = 36,
		Height = 36,
		Point = "CENTER",
		RelPoint = "CENTER",
		OffsetX = 0,
		OffsetY = 0,
		UseColor = true,
		-- SetAllPoints = true,
	},
	ContextOverlay = "SearchOverlay",
```